### PR TITLE
Remove librt for macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,10 @@ target_include_directories(util
 target_link_libraries(util PUBLIC fmt::fmt)
 
 if(UNIX)
-    target_link_libraries(util PUBLIC pthread rt)
+    target_link_libraries(util PUBLIC pthread)
+    if(NOT APPLE)
+        target_link_libraries(util PUBLIC rt)
+    endif()
 endif()
 if(WIN32)
     target_link_libraries(util PUBLIC winmm Pdh Version)


### PR DESCRIPTION
I was trying to build mahilab/mahi-util on macOS (Apple Clang) and got a linking error because you link librt on Unix systems. This library is not available for me. With this small change, I'm now able to build and run the demo applications.