### PR TITLE
Fix Linux build. Rmove #include <sys/sysctl.h>

### DIFF
--- a/src/Mahi/Util/System.cpp
+++ b/src/Mahi/Util/System.cpp
@@ -18,7 +18,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <errno.h>
-#include <sys/sysctl.h>
 #endif
 
 namespace mahi {


### PR DESCRIPTION
It doesn't appear that the sysctl call is being used, and has long been deprecated in Linux.