### PR TITLE
updating keyboard enums and fixing get_key for windows keys

### DIFF
--- a/examples/ex_keyboard.cpp
+++ b/examples/ex_keyboard.cpp
@@ -31,11 +31,11 @@ int main(int argc, char const *argv[])
     std::cout << "get_key() is blocking, so now you must press \"Enter\" or \"Esc\" before continuing this example" << std::endl;
     // Enter and KEY_ESCAPE are 0 and 1, so we will initialize ch to -1 so that we don't automatically hit the case
     int ch = -1;
-    while(ch != (int)KEY_ENTER && ch != (int)KEY_ESCAPE) {
+    while(ch != KEY_ENTER && ch != KEY_ESCAPE) {
         // waits until we get a keypress and then assigns that key value to ch
         ch = get_key();
         // if the user doesn't press k, tell them they made a mistake, and tell them to press K!
-        if(ch != (int)KEY_ENTER && ch != (int)KEY_ESCAPE) std::cout << "Silly you, you have to press \"Enter\" or \"Esc\", not " << (unsigned char)toupper(ch) << std::endl;
+        if(ch != KEY_ENTER && ch != KEY_ESCAPE) std::cout << "Silly you, you have to press \"Enter\" or \"Esc\", not " << (unsigned char)toupper(ch) << std::endl;
     }
     
     

--- a/examples/ex_keyboard.cpp
+++ b/examples/ex_keyboard.cpp
@@ -1,9 +1,61 @@
-#include <Mahi/Util.hpp>
+#include <Mahi/Util/Console.hpp>
+#include <Mahi/Util/Timing/Clock.hpp>
 
 using namespace mahi::util;
 
-// See JSON for Modern C++ for more examples:
-// https://github.com/nlohmann/json
+std::string get_key_string(int key_press){
+    switch (key_press){
+        case KEY_BACKSPACE: return "BACKSPACE";
+        case KEY_TAB: return "TAB";
+        case KEY_ENTER: return "ENTER";
+        case KEY_ESCAPE: return "ESCAPE";
+        case KEY_SPACE: return "SPACE";
+
+        case KEY_NUM0: return "NUM0";
+        case KEY_NUM1: return "NUM1";
+        case KEY_NUM2: return "NUM2";
+        case KEY_NUM3: return "NUM3";
+        case KEY_NUM4: return "NUM4";
+        case KEY_NUM5: return "NUM5";
+        case KEY_NUM6: return "NUM6";
+        case KEY_NUM7: return "NUM7";
+        case KEY_NUM8: return "NUM8";
+        case KEY_NUM9: return "NUM9";
+
+        case KEY_F1: return "F1";
+        case KEY_F2: return "F2";
+        case KEY_F3: return "F3";
+        case KEY_F4: return "F4";
+        case KEY_F5: return "F5";
+        case KEY_F6: return "F6";
+        case KEY_F7: return "F7";
+        case KEY_F8: return "F8";
+        case KEY_F9: return "F9";
+        case KEY_F10: return "F10";
+        case KEY_F11: return "F11";
+        case KEY_F12: return "F12";
+
+        case KEY_HOME: return "HOME";
+        case KEY_UP: return "UP";
+        case KEY_PGUP: return "PGUP";
+        case KEY_LEFT: return "LEFT";
+        case KEY_RIGHT: return "RIGHT";
+        case KEY_END: return "END";
+        case KEY_DOWN: return "DOWN";
+        case KEY_PGDOWN: return "PGDOWN";
+        case KEY_INSERT: return "INSERT";
+        case KEY_DELETE: return "DELETE";
+        default: {
+            if (key_press >= 65 && key_press <= 122){
+                int upper_int = toupper(key_press);
+                return std::string((char*)&upper_int);
+            }
+            else{
+                return "UNMAPPED KEY";
+            }
+        }
+    }
+}
 
 int main(int argc, char const *argv[])
 {   
@@ -35,7 +87,10 @@ int main(int argc, char const *argv[])
         // waits until we get a keypress and then assigns that key value to ch
         ch = get_key();
         // if the user doesn't press k, tell them they made a mistake, and tell them to press K!
-        if(ch != KEY_ENTER && ch != KEY_ESCAPE) std::cout << "Silly you, you have to press \"Enter\" or \"Esc\", not " << (unsigned char)toupper(ch) << std::endl;
+        if(ch != KEY_ENTER && ch != KEY_ESCAPE) {
+            std::string key_pressed = get_key_string(ch);
+            std::cout << "Silly you, you have to press \"Enter\" or \"Esc\", not " << key_pressed << std::endl;
+        }
     }
     
     

--- a/include/Mahi/Util/Console.hpp
+++ b/include/Mahi/Util/Console.hpp
@@ -123,9 +123,10 @@ void cls();
 
 /// Key Codes
 enum {
-    KEY_ESCAPE    = 0,
+    KEY_ESCAPE    = 27,
     KEY_ENTER     = 1,
     KEY_BACKSPACE = 8,
+    KEY_TAB       = 9,
     KEY_SPACE     = 32,
 
     KEY_INSERT = 2,

--- a/include/Mahi/Util/Console.hpp
+++ b/include/Mahi/Util/Console.hpp
@@ -121,50 +121,50 @@ void beep();
 /// Clears screen, resets all attributes and moves cursor home (thread-safe)
 void cls();
 
-/// Key Codes
+constexpr int AsciiEscape = 200; // arbitrary number to represent escape sequence before enums
+
+/// Key Codes based on microsoft ascii codes https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)
 enum {
-    KEY_ESCAPE    = 27,
-    KEY_ENTER     = 1,
     KEY_BACKSPACE = 8,
     KEY_TAB       = 9,
+    KEY_ENTER     = 13,
+    KEY_ESCAPE    = 27,
     KEY_SPACE     = 32,
 
-    KEY_INSERT = 2,
-    KEY_HOME   = 3,
-    KEY_PGUP   = 4,
-    KEY_DELETE = 5,
-    KEY_END    = 6,
-    KEY_PGDOWN = 7,
+    KEY_NUM0 = 48,
+    KEY_NUM1 = 49,
+    KEY_NUM2 = 50,
+    KEY_NUM3 = 51,
+    KEY_NUM4 = 52,
+    KEY_NUM5 = 53,
+    KEY_NUM6 = 54,
+    KEY_NUM7 = 55,
+    KEY_NUM8 = 56,
+    KEY_NUM9 = 57,
 
-    KEY_UP    = 14,
-    KEY_DOWN  = 15,
-    KEY_LEFT  = 16,
-    KEY_RIGHT = 17,
+    KEY_F1  = AsciiEscape + 59,
+    KEY_F2  = AsciiEscape + 60,
+    KEY_F3  = AsciiEscape + 61,
+    KEY_F4  = AsciiEscape + 62,
+    KEY_F5  = AsciiEscape + 63,
+    KEY_F6  = AsciiEscape + 64,
+    KEY_F7  = AsciiEscape + 65,
+    KEY_F8  = AsciiEscape + 66,
+    KEY_F9  = AsciiEscape + 67,
+    KEY_F10 = AsciiEscape + 68,
+    KEY_F11 = AsciiEscape + 69,
+    KEY_F12 = AsciiEscape + 70,
 
-    KEY_F1  = 18,
-    KEY_F2  = 19,
-    KEY_F3  = 20,
-    KEY_F4  = 21,
-    KEY_F5  = 22,
-    KEY_F6  = 23,
-    KEY_F7  = 24,
-    KEY_F8  = 25,
-    KEY_F9  = 26,
-    KEY_F10 = 27,
-    KEY_F11 = 28,
-    KEY_F12 = 29,
-
-    KEY_NUMDEL  = 30,
-    KEY_NUMPAD0 = 31,
-    KEY_NUMPAD1 = 127,
-    KEY_NUMPAD2 = 128,
-    KEY_NUMPAD3 = 129,
-    KEY_NUMPAD4 = 130,
-    KEY_NUMPAD5 = 131,
-    KEY_NUMPAD6 = 132,
-    KEY_NUMPAD7 = 133,
-    KEY_NUMPAD8 = 134,
-    KEY_NUMPAD9 = 135
+    KEY_HOME   = AsciiEscape + 71,
+    KEY_UP     = AsciiEscape + 72,
+    KEY_PGUP   = AsciiEscape + 73,
+    KEY_LEFT   = AsciiEscape + 75,
+    KEY_RIGHT  = AsciiEscape + 77,
+    KEY_END    = AsciiEscape + 79,
+    KEY_DOWN   = AsciiEscape + 80,
+    KEY_PGDOWN = AsciiEscape + 81,
+    KEY_INSERT = AsciiEscape + 82,
+    KEY_DELETE = AsciiEscape + 83
 };
 
 }  // namespace util

--- a/src/Mahi/Util/Console.cpp
+++ b/src/Mahi/Util/Console.cpp
@@ -352,7 +352,7 @@ int get_key(void) {
                 case 81: return KEY_PGDOWN;
                 case 82: return KEY_INSERT;
                 case 83: return KEY_DELETE;
-                default: return kk-59+KEY_F1; // Function keys
+                default: return kk-59 + KEY_F1; // Function keys
             }}
         case 224: {
             int kk;
@@ -367,7 +367,9 @@ int get_key(void) {
                 case 81: return KEY_PGDOWN;
                 case 82: return KEY_INSERT;
                 case 83: return KEY_DELETE;
-                default: return kk-123+KEY_F1; // Function keys
+                case 133: return KEY_F11;
+                case 134: return KEY_F12;
+                default: return kk; // Catch all
             }}
 #ifdef __APPLE__
         case 10:  return KEY_ENTER;
@@ -376,6 +378,17 @@ int get_key(void) {
         case 8:  return KEY_BACKSPACE;
         case 9:  return KEY_TAB;
         case 13: return KEY_ENTER;
+        case 32: return KEY_SPACE;
+        case 48: return KEY_NUM0;
+        case 49: return KEY_NUM1;
+        case 50: return KEY_NUM2;
+        case 51: return KEY_NUM3;
+        case 52: return KEY_NUM4;
+        case 53: return KEY_NUM5;
+        case 54: return KEY_NUM6;
+        case 55: return KEY_NUM7;
+        case 56: return KEY_NUM8;
+        case 57: return KEY_NUM9;
 #endif
 
 #ifdef _WIN32

--- a/src/Mahi/Util/Console.cpp
+++ b/src/Mahi/Util/Console.cpp
@@ -352,7 +352,7 @@ int get_key(void) {
                 case 81: return KEY_PGDOWN;
                 case 82: return KEY_INSERT;
                 case 83: return KEY_DELETE;
-                default: return kk-59 + KEY_F1; // Function keys
+                default: return kk; // Function keys
             }}
         case 224: {
             int kk;

--- a/src/Mahi/Util/Console.cpp
+++ b/src/Mahi/Util/Console.cpp
@@ -342,16 +342,16 @@ int get_key(void) {
         case 0: {
             int kk;
             switch (kk = getch()) {
-                case 71: return KEY_NUMPAD7;
-                case 72: return KEY_NUMPAD8;
-                case 73: return KEY_NUMPAD9;
-                case 75: return KEY_NUMPAD4;
-                case 77: return KEY_NUMPAD6;
-                case 79: return KEY_NUMPAD1;
-                case 80: return KEY_NUMPAD2;
-                case 81: return KEY_NUMPAD3;
-                case 82: return KEY_NUMPAD0;
-                case 83: return KEY_NUMDEL;
+                case 71: return KEY_HOME;
+                case 72: return KEY_UP;
+                case 73: return KEY_PGUP;
+                case 75: return KEY_LEFT;
+                case 77: return KEY_RIGHT;
+                case 79: return KEY_END;
+                case 80: return KEY_DOWN;
+                case 81: return KEY_PGDOWN;
+                case 82: return KEY_INSERT;
+                case 83: return KEY_DELETE;
                 default: return kk-59+KEY_F1; // Function keys
             }}
         case 224: {
@@ -373,8 +373,9 @@ int get_key(void) {
         case 10:  return KEY_ENTER;
         case 127: return KEY_BACKSPACE;
 #else
-        case 10: return KEY_ENTER;
         case 8:  return KEY_BACKSPACE;
+        case 9:  return KEY_TAB;
+        case 13: return KEY_ENTER;
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
There are 2 fixes in this PR
- updating enums so that `esc` doesn't interfere with no key-hit on non-blocking keyboard apis 
- fixing `get_key` function for several cases, including `esc`, `enter`, and arrow keys that were incorrectly labeled. See [this](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)) for correct key codes

The main thing to check if this works, is to see if the ex_keyboard example runs correctly. Using `enter` didn't work previously for the portion asking for enter or escape.